### PR TITLE
Upgrade Apache Commons dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.20.0</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14.0</version>
+            <version>2.21.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Description

This PR updates Apache Commons dependencies to newer stable versions:

- commons-io: 2.14.0 → 2.21.0
- commons-lang3: 3.9 → 3.20.0
