### PR TITLE
Upgrade Spring Boot to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <description>Remote Code Execution</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.4.RELEASE</version>
+        <version>4.0.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>edu.pec</groupId>

--- a/src/main/java/edu/pec/dromeas/controller/ExecuteController.java
+++ b/src/main/java/edu/pec/dromeas/controller/ExecuteController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/run")

--- a/src/main/java/edu/pec/dromeas/payload/Code.java
+++ b/src/main/java/edu/pec/dromeas/payload/Code.java
@@ -2,7 +2,7 @@ package edu.pec.dromeas.payload;
 
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 public class Code


### PR DESCRIPTION
- Bump Spring Boot from 2.2.4.RELEASE → 4.0.1
- Upgrade Java version from 1.8 → 21
- Add spring-boot-starter-validation dependency
- Replace javax.validation.* imports with jakarta.validation.* in controllers and payloads

These changes ensure compatibility with Spring Boot 4 and Jakarta EE 10 validation APIs.